### PR TITLE
fix: helper-scripts-cs

### DIFF
--- a/.helper/scripts/build.php
+++ b/.helper/scripts/build.php
@@ -1,10 +1,7 @@
 <?php
 
-$dir = substr(
-    __DIR__,
-    0,
-    strpos(__DIR__, DIRECTORY_SEPARATOR.'.helper')
-);
+$sep = DIRECTORY_SEPARATOR;
+$dir = substr(__DIR__, 0, strpos(__DIR__, $sep.'.helper'));
 
 require_once $dir.'/.helper/vendor/autoload.php';
 

--- a/.helper/scripts/token.php
+++ b/.helper/scripts/token.php
@@ -1,10 +1,7 @@
 <?php
 
-$dir = substr(
-    __DIR__,
-    0,
-    strpos(__DIR__, DIRECTORY_SEPARATOR.'.helper')
-);
+$sep = DIRECTORY_SEPARATOR;
+$dir = substr(__DIR__, 0, strpos(__DIR__, $sep.'.helper'));
 
 require_once $dir.'/.helper/vendor/autoload.php';
 


### PR DESCRIPTION
using variable to store directory separator on helper scripts